### PR TITLE
Imprint values

### DIFF
--- a/src/components/hero/hero.jsx
+++ b/src/components/hero/hero.jsx
@@ -1033,7 +1033,7 @@ class Hero extends Component {
       ],
        // imprintIncreases[index][numDirections-1][rarity-3]
       imprintIncreases: [
-        [ // index 0 - ATK DEF HP - Flat
+        [ // index 0 - ATK - Flat
           [], // 1 direction
           [], // 2 directions
           [], // 3 directions
@@ -1043,7 +1043,27 @@ class Hero extends Component {
             [{}]
           ]
         ],
-        [ // index 1 - ATK DEF HP - Percent
+        [ // index 1 - DEF - Flat
+          [], // 1 direction
+          [], // 2 directions
+          [], // 3 directions
+          [ // all(4) directions
+            [{d:12, c:18, b:24, a:30, s:36, ss:42, sss:48}],
+            [{}],
+            [{}]
+          ]
+        ],
+        [ // index 2 - HP - Flat
+          [], // 1 direction
+          [], // 2 directions
+          [], // 3 directions
+          [ // all(4) directions
+            [{d:120, c:180, b:240, a:300, s:360, ss:420, sss:480}],
+            [{}],
+            [{}]
+          ]
+        ],
+        [ // index 3 - ATK DEF HP - Percent
           [], // 1 direction
           [ // 2 directions
             [{}],
@@ -1057,7 +1077,7 @@ class Hero extends Component {
             [{d:0, c:0, b:"3.6%", a:"5.4%", s:"7.2%", ss:"9%", sss:"10.8%"}]
           ]
         ],
-        [ // index 2 - SPD - Flat
+        [ // index 4 - SPD - Flat
           [], // 1 direction
           [ // 2 directions
             [{}],
@@ -1071,7 +1091,7 @@ class Hero extends Component {
             [{d:0, c:0, b:4, a:6, s:8, ss:10, sss:12}]
           ]
         ],
-        [ // index 3 - CHC EFF EFR - Percent
+        [ // index 5 - CHC EFF EFR - Percent
           [], // 1 direction
           [ // 2 directions
             [{}],
@@ -1085,7 +1105,7 @@ class Hero extends Component {
             [{d:0, c:0, b:"4.8%", a:"7.2%", s:"9.6%", ss:"12%", sss:"14.4%"}]
           ]
         ],
-        [ // index 3 - DAC - Percent
+        [ // index 6 - DAC - Percent
           [], // 1 direction
           [ // 2 directions
             [{}],
@@ -1102,15 +1122,15 @@ class Hero extends Component {
       ],
       // imprintIncreasesIndex[stat][flatOrPercent]
       imprintIncreasesIndex: [
-          [{index: 0}, {index: 1}], // Attack
-          [{index: 0}, {index: 1}], // Defense
-          [{index: 0}, {index: 1}], // Health
-          [{index: 2}, {}        ], // Speed
-          [{},         {index: 3}], // Critical Hit Chance
+          [{index: 0}, {index: 3}], // Attack
+          [{index: 1}, {index: 3}], // Defense
+          [{index: 2}, {index: 3}], // Health
+          [{index: 4}, {}        ], // Speed
+          [{},         {index: 5}], // Critical Hit Chance
           [{},         {}        ], // Critical Hit Damage
-          [{},         {index: 3}], // Effectiveness
-          [{},         {index: 3}], // Effect Resistance
-          [{},         {index: 4}]  // Dual Attack Chance
+          [{},         {index: 5}], // Effectiveness
+          [{},         {index: 5}], // Effect Resistance
+          [{},         {index: 6}]  // Dual Attack Chance
       ],
       rarity: [
         { label: "3 ★★★", value: 3 },

--- a/src/components/hero/hero.jsx
+++ b/src/components/hero/hero.jsx
@@ -1031,6 +1031,87 @@ class Hero extends Component {
           ]
         ]
       ],
+       // imprintIncreases[index][numDirections-1][rarity-3]
+      imprintIncreases: [
+        [ // index 0 - ATK DEF HP - Flat
+          [], // 1 direction
+          [], // 2 directions
+          [], // 3 directions
+          [ // all(4) directions
+            [{d:24, c:36, b:48, a:60, s:72, ss:84, sss:96}],
+            [{}],
+            [{}]
+          ]
+        ],
+        [ // index 1 - ATK DEF HP - Percent
+          [], // 1 direction
+          [ // 2 directions
+            [{}],
+            [{d:0, c:"2.9%", b:"3.6%", a:"5.8%", s:"7.2%", ss:"8.7%", sss:"10.2%"}],
+            [{d:0, c:0, b:"4.3%", a:"6.4%", s:"8.6%", ss:"10.7%", sss:"12.9%"}]
+          ]
+          [], // 3 directions
+          [ // all(4) directions
+            [{}],
+            [{d:0, c:"2.4%", b:"3.6%", a:"4.8%", s:"6%", ss:"6.2%", sss:"7.4%"}],
+            [{d:0, c:0, b:"3.6%", a:"5.4%", s:"7.2%", ss:"9%", sss:"10.8%"}]
+          ]
+        ],
+        [ // index 2 - SPD - Flat
+          [], // 1 direction
+          [ // 2 directions
+            [{}],
+            [{d:0, c:4, b:6, a:8, s:10, ss:12, sss:14}],
+            [{}]
+          ]
+          [], // 3 directions
+          [ // all(4) directions
+            [{d:2, c:3, b:4, a:5, s:6, ss:7, sss:8}],
+            [{d:0, c:3, b:4, a:6, s:7, ss:9, sss:10}],
+            [{d:0, c:0, b:4, a:6, s:8, ss:10, sss:12}]
+          ]
+        ],
+        [ // index 3 - CHC EFF EFR - Percent
+          [], // 1 direction
+          [ // 2 directions
+            [{}],
+            [{d:0, c:"4.3%", b:"6.5%", a:"8.6%", s:"10.7%", ss:"12.9%", sss:"15%"}],
+            [{d:0, c:0, b:"5.8%", a:"8.7%", s:"11.6%", ss:"14.5%", sss:"17.4%"}]
+          ]
+          [], // 3 directions
+          [ // all(4) directions
+            [{}],
+            [{d:0, c:"3.6%", b:"5.4%", a:"7.2%", s:"9%", ss:"10.8%", sss:"12.6%"}],
+            [{d:0, c:0, b:"4.8%", a:"7.2%", s:"9.6%", ss:"12%", sss:"14.4%"}]
+          ]
+        ],
+        [ // index 3 - DAC - Percent
+          [], // 1 direction
+          [ // 2 directions
+            [{}],
+            [{d:0, c:"0.9%", b:"1.3%", a:"1.8%", s:"2.2%", ss:"2.7%", sss:"3.1%"}],
+            [{}]
+          ]
+          [], // 3 directions
+          [ // all(4) directions
+            [{}],
+            [{d:0, c:"0.7%", b:"1.0%", a:"1.4%", s:"1.7%", ss:"2.1%", sss:"2.4%"}],
+            [{}]
+          ]
+        ],
+      ],
+      // imprintIncreasesIndex[stat][flatOrPercent]
+      imprintIncreasesIndex: [
+          [{index: 0}, {index: 1}], // Attack
+          [{index: 0}, {index: 1}], // Defense
+          [{index: 0}, {index: 1}], // Health
+          [{index: 2}, {}        ], // Speed
+          [{},         {index: 3}], // Critical Hit Chance
+          [{},         {}        ], // Critical Hit Damage
+          [{},         {index: 3}], // Effectiveness
+          [{},         {index: 3}], // Effect Resistance
+          [{},         {index: 4}]  // Dual Attack Chance
+      ],
       rarity: [
         { label: "3 ★★★", value: 3 },
         { label: "4 ★★★★", value: 4 },


### PR DESCRIPTION
The imprint increases are the same for all heroes with the same stat, formation count, rarity.

This change adds a variable imprintIncreasesIndex[stat][flatOrPercent], which is a table that provides a index. (0 for flat, 1 for percent)
This index can be used in imprintIncreases[index][numDirections-1][rarity-3], to figure out the imprint increase values.

Many of the stats share the same increases, so there was no need to duplicate the code 6 extra times. ATK, DEF, HP.


The idea would be to gather the following data and get the values needed:
Hero rarity
Imprint stat name
Imprint flat or percent
Number of Directions

It would probably be best to keep it editable if possible as I had to leave a bunch blank as I am not seeing any units that follow that stat. Like no 4*s have flat stats, so it is all empty, but it is possible in future they could be added.


Might be worth while having an "Auto" button that will trigger filling in data.